### PR TITLE
Support suffix matching in the same style as prefix matching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ with the string "autosnap_"
 
     zfs-prune-snapshots -p 'autosnap_' 1M zones
 
+Remove snapshots older than two months on the tank pool that end
+with the string "_frequent"
+
+    zfs-prune-snapshots -s '_frequent' 2M tank
+
 Timespec
 --------
 
@@ -64,6 +69,10 @@ Usage
         remove snapshots older than a month on the zones pool that start
         with the string "autosnap_"
 
+        # zfs-prune-snapshots -s '_frequent' 2M tank
+        remove snapshots older than two months on the tank pool that end
+        with the string "_frequent"
+
     timespec
         the first argument denotes how old a snapshot must be for it to
         be considered for deletion - possible specifiers are
@@ -80,6 +89,7 @@ Usage
         -h             print this message and exit
         -n             dry-run, don't actually delete snapshots
         -p <prefix>    snapshot prefix string to match
+        -s <suffix>    snapshot suffix string to match
         -q             quiet, do not printout removed snapshots
         -v             increase verbosity
         -V             print the version number and exit

--- a/man/zfs-prune-snapshots.1
+++ b/man/zfs-prune-snapshots.1
@@ -21,6 +21,9 @@ dry\-run, don't actually delete snapshots
 \fB\fC\-p <prefix>\fR
 snapshot prefix string to match
 .TP
+\fB\fC\-s <suffix>\fR
+snapshot suffix string to match
+.TP
 \fB\fC\-q\fR
 quiet, do not printout removed snapshots
 .TP
@@ -65,6 +68,10 @@ tank2/backup
 \fB\fCzfs\-prune\-snapshots \-p 'autosnap_' 1M zones\fR
 Remove snapshots older than a month on the zones pool that start with the
 string \fB\fC"autosnap_"\fR
+.TP
+\fB\fCzfs\-prune\-snapshots \-s '_frequent' 2M tank\fR
+Remove snapshots older than two months on the tank pool that end with the
+string \fB\fC"_frequent"\fR
 .SH BUGS
 .PP
 \[la]https://github.com/bahamas10/zfs-prune-snapshots\[ra]

--- a/man/zfs-prune-snapshots.md
+++ b/man/zfs-prune-snapshots.md
@@ -30,6 +30,9 @@ OPTIONS
 `-p <prefix>`
   snapshot prefix string to match
 
+`-s <suffix>`
+  snapshot suffix string to match
+
 `-q`
   quiet, do not printout removed snapshots
 
@@ -76,6 +79,10 @@ EXAMPLES
 `zfs-prune-snapshots -p 'autosnap_' 1M zones`
   Remove snapshots older than a month on the zones pool that start with the
   string `"autosnap_"`
+
+`zfs-prune-snapshots -s '_frequent' 2M tank`
+  Remove snapshots older than two months on the tank pool that end with the
+  string `"_frequent"`
 
 BUGS
 ----

--- a/zfs-prune-snapshots
+++ b/zfs-prune-snapshots
@@ -11,7 +11,7 @@ VERSION='v1.0.1'
 usage() {
 	local prog=${0##*/}
 	cat <<-EOF
-	usage: $prog [-hnv] [-p <prefix] <time> [[dataset1] ...]
+	usage: $prog [-hnv] [-p <prefix>] [-s <suffix>] <time> [[dataset1] ...]
 
 	remove snapshots from one or more zpools that match given criteria
 
@@ -32,6 +32,10 @@ usage() {
 	    remove snapshots older than a month on the zones pool that start
 	    with the string "autosnap_"
 
+	    # $prog -s '_frequent' 2M tank
+	    remove snapshots older than two months on the tank pool that end
+	    with the string "_frequent"
+
 	timespec
 	    the first argument denotes how old a snapshot must be for it to
 	    be considered for deletion - possible specifiers are
@@ -48,6 +52,7 @@ usage() {
 	    -h             print this message and exit
 	    -n             dry-run, don't actually delete snapshots
 	    -p <prefix>    snapshot prefix string to match
+	    -s <suffix>    snapshot suffix string to match
 	    -q             quiet, do not printout removed snapshots
 	    -v             increase verbosity
 	    -V             print the version number and exit
@@ -93,12 +98,14 @@ human() {
 dryrun=false
 verbosity=0
 prefix=
+suffix=
 quiet=false
-while getopts 'hnqp:vV' option; do
+while getopts 'hnqp:s:vV' option; do
 	case "$option" in
 		h) usage; exit 0;;
 		n) dryrun=true;;
 		p) prefix=$OPTARG;;
+		s) suffix=$OPTARG;;
 		q) quiet=true;;
 		v) ((verbosity++));;
 		V) echo "$VERSION"; exit 0;;
@@ -145,6 +152,12 @@ while read -r creation snapshot; do
 	snapname=${snapshot#*@}
 	if [[ -n $prefix && $prefix != "${snapname:0:${#prefix}}" ]]; then
 		debug "skipping $snapshot: doesn't match prefix $prefix"
+		continue
+	fi
+
+	# ensure optional suffix matches
+	if [[ -n $suffix && $suffix != "${snapname: -${#suffix}}" ]]; then
+		debug "skipping $snapshot: doesn't match suffix $suffix"
 		continue
 	fi
 


### PR DESCRIPTION
The [zfs-auto-snapshot](https://github.com/zfsonlinux/zfs-auto-snapshot.git) script can name snapshots with the form `<prefix>_<timestamp>_<label>` to allow different rolloff cycles for different snapshot frequencies. (For example, keep the last 4 quarter-hourly snapshots, 24 hourly snapshots, 31 daily snapshots, and so on.) This request adds support for suffix matching to allow `zfs-prune-snapshots` to be used in a similar manner, with frequencies and lifetimes determined by suffix in addition to prefix.