### PR TITLE
Run only on existing pools

### DIFF
--- a/zfs-prune-snapshots
+++ b/zfs-prune-snapshots
@@ -143,7 +143,16 @@ else
 fi
 
 shift
-pools=("$@")
+declare -a pools
+for myarg in "$@"; do
+	if ! $(zfs list $myarg &>/dev/null); then
+		if ! $quiet; then
+			echo "Pool $myarg does not exist."
+		fi
+	else
+		pools+=("$myarg")
+	fi
+done
 
 now=$(date +%s)
 code=0


### PR DESCRIPTION
Just in case a given pool does not exist. 
Story:
I specified all of the possible pool names in a cron file which gets distributed on all machines. Not all of the pools exist on every machine and I wanted to avoid "dataset does not exist" from zfs so ended up with this modification. The pools array gets filled only with actual datasets, non-existent will be skipped. Output depends on quiet mode. 
What do you think?