### PR TITLE
Allow snapshot datasets to contain spaces

### DIFF
--- a/zfs-prune-snapshots
+++ b/zfs-prune-snapshots
@@ -246,7 +246,7 @@ fi
 # first pass of the pools (to calculate totals and filter unwanted datasets
 lines=()
 while read -r line; do
-	read -r creation used snapshot _ <<< "$line"
+	read -r creation used snapshot <<< "$line"
 
 	# ensure optional prefix matches
 	snapname=${snapshot#*@}
@@ -317,7 +317,7 @@ echo "found $numsnapshots snapshots ($humantotal) on pools: $humanpools"
 # process snapshots found
 i=0
 for line in "${lines[@]}"; do
-	read -r creation used snapshot _ <<< "$line"
+	read -r creation used snapshot <<< "$line"
 
 	((i++))
 


### PR DESCRIPTION
Previously, the `read -r` command ignored content after the first space in a dataset/snapshot name. For example, when trying to remove `MyPool/Media/TV Shows@snapshot-name`, the program would try to instead destroy `MyPool/Media/TV` which (probably) doesn't exist and is a dataset as opposed to a snapshot. This change should be safe because the `zfs list` command will not return any extra information after the creation time, space used, and snapshot name, in that order.